### PR TITLE
fix: ignore merge commits even if they have a type

### DIFF
--- a/bumper.js
+++ b/bumper.js
@@ -43,21 +43,23 @@ module.exports = function bumper(config = {}) {
 
                 //console.log(commits);
                 commits.forEach(commit => {
-                    addBangNotes(commit); //add notes if breaking change or with "!"
+                    if(commit.merge === null){
+                        addBangNotes(commit); //add notes if breaking change or with "!"
 
-                    //it looks like in cc preset it's the way to detect breaking change.
-                    //if other notes types are added, it would be better to add a "breaking" property to the commit
-                    if (commit.notes.length > 0) {
-                        breakings++;
-                        level = 0;
-                    }
-                    if (commit.type === 'feat' || commit.type === 'feature') {
-                        features++;
-                        if (level === 2) {
-                            level = 1;
+                        //it looks like in cc preset it's the way to detect breaking change.
+                        //if other notes types are added, it would be better to add a "breaking" property to the commit
+                        if (commit.notes.length > 0) {
+                            breakings++;
+                            level = 0;
                         }
-                    } else if (commit.type === 'fix') {
-                        fixes++;
+                        if (commit.type === 'feat' || commit.type === 'feature') {
+                            features++;
+                            if (level === 2) {
+                                level = 1;
+                            }
+                        } else if (commit.type === 'fix') {
+                            fixes++;
+                        }
                     }
                 });
 

--- a/bumper.js
+++ b/bumper.js
@@ -43,7 +43,7 @@ module.exports = function bumper(config = {}) {
 
                 //console.log(commits);
                 commits.forEach(commit => {
-                    if(commit.merge === null){
+                    if (commit.merge === null) {
                         addBangNotes(commit); //add notes if breaking change or with "!"
 
                         //it looks like in cc preset it's the way to detect breaking change.

--- a/tests/bumper/test.js
+++ b/tests/bumper/test.js
@@ -136,7 +136,8 @@ test('whatBump returns correct level, reason and stats with a breaking change in
             id: '106',
             source: 'oat-sa/fix/BBQ-987/cap-grill-temparature',
             merge: 'Merge pull request #106 from oat-sa/fix/BBQ-987/cap-grill-temparature',
-            header: 'Fix/bbq 987/cap grill temparature'
+            type: 'fix',
+            header: 'fix: cap grill temparature'
         }),
         getCommit({
             type: 'fix',
@@ -227,9 +228,10 @@ test('whatBump returns correct level, reason and stats without any conv commit',
     const commits = [
         getCommit({
             id: '106',
+            type: 'feat',
             source: 'oat-sa/fix/BBQ-987/cap-grill-temparature',
             merge: 'Merge pull request #106 from oat-sa/fix/BBQ-987/cap-grill-temparature',
-            header: 'Fix/bbq 987/cap grill temparature'
+            header: 'feat: cap grill temparature'
         }),
         getCommit({
             subject: 'update controller with new bbq master',


### PR DESCRIPTION
Small fix because it seems that a merge commit parsed by https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits can also have a type, like the following example
```
[ { type: 'feat',
    scope: null,
    subject: 'new moo controller feature',
    source: 'oat-sa/feature/OTA-654/brand-new-feature',
    destination: null,
    id: '130',
    merge:
     'Merge pull request #130 from oat-sa/feature/OTA-654/brand-new-feature',
    header: 'feat: new moo controller feature',
    body: null,
    footer: null,
    notes: [],
    references: [],
    mentions: [],
    revert: null,
    hash: 'b46f15fe672bfbc6cb64e20c6872f69775b2229b' },
  { type: 'feat',
    scope: null,
    subject: 'new moo controller feature',
    source: null,
    destination: null,
    id: null,
    merge: null,
    header: 'feat: new moo controller feature',
    body: null,
    footer: null,
    notes: [],
    references: [],
    mentions: [],
    revert: null,
    hash: '43e20687d3cc0433722f75cdfaa400d606bc9416' } ]
```

How to test: 
 - run the unit tests

Note: 
 - I've not bumped the version to test the new release tool version on this repo  